### PR TITLE
styling: ensure background gradient always fills page

### DIFF
--- a/src/assets/styles/scss/partials/01-Abstract/_settings.scss
+++ b/src/assets/styles/scss/partials/01-Abstract/_settings.scss
@@ -12,12 +12,14 @@
 /// 62rem * 16px = 992px; not in use yet
 /// 64rem * 16px = 1024px;
 /// 80rem * 16px = 1280px;
+/// 90rem * 16px = 1440px
 $breakpoints: (
-  "xs": 36em,
-  "sm": 48em,
-  "md": 60em,
-  "lg": 64em,
-  "xl": 80em,
+  "xs":  36em,
+  "sm":  48em,
+  "md":  60em,
+  "lg":  64em,
+  "xl":  80em,
+  "xxl": 90em,
 ) !default;
 
 // Palette generated with -->

--- a/src/assets/styles/scss/partials/02-Generic/_common.scss
+++ b/src/assets/styles/scss/partials/02-Generic/_common.scss
@@ -84,6 +84,9 @@
     background-image: url("/assets/images/mesh-gradient-black.webp");
     background-repeat: no-repeat;
     background-size: contain;
+    @include media-query(xxl) {
+      background-size: cover;
+    }
   }
 }
 
@@ -92,4 +95,7 @@
   background-image: url("/assets/images/mesh-gradient-black.jpg");
   background-repeat: no-repeat;
   background-size: contain;
+  @include media-query(xxl) {
+    background-size: cover;
+  }
 }

--- a/src/assets/styles/scss/partials/05-Templates/_home-tmpl.scss
+++ b/src/assets/styles/scss/partials/05-Templates/_home-tmpl.scss
@@ -14,6 +14,9 @@
   background-image: url("/assets/images/mesh-gradient-white.webp");
   background-repeat: no-repeat;
   background-size: contain;
+  @include media-query(xxl) {
+    background-size: cover;
+  }
 }
 
 /*! purgecss ignore */
@@ -21,4 +24,7 @@
   background-image: url("/assets/images/mesh-gradient-white.jpg");
   background-repeat: no-repeat;
   background-size: contain;
+  @include media-query(xxl) {
+    background-size: cover;
+  }
 }

--- a/src/assets/styles/scss/partials/08-MQ/_dark-theme.scss
+++ b/src/assets/styles/scss/partials/08-MQ/_dark-theme.scss
@@ -41,6 +41,9 @@
     background-image: url("/assets/images/mesh-gradient-black.webp");
     background-repeat: no-repeat;
     background-size: contain;
+    @include media-query(xxl) {
+      background-size: cover;
+    }
   }
 
   /*! purgecss ignore */
@@ -48,6 +51,9 @@
     background-image: url("/assets/images/mesh-gradient-black.jpg");
     background-repeat: no-repeat;
     background-size: contain;
+    @include media-query(xxl) {
+      background-size: cover;
+    }
   }
 
   .light-theme {
@@ -92,6 +98,9 @@
     background-image: url("/assets/images/mesh-gradient-white.webp");
     background-repeat: no-repeat;
     background-size: contain;
+    @include media-query(xxl) {
+      background-size: cover;
+    }
   }
 
   /*! purgecss ignore */
@@ -99,5 +108,8 @@
     background-image: url("/assets/images/mesh-gradient-white.jpg");
     background-repeat: no-repeat;
     background-size: contain;
+    @include media-query(xxl) {
+      background-size: cover;
+    }
   }
 }


### PR DESCRIPTION
## Expected Behavior

![image](https://user-images.githubusercontent.com/63189531/141945626-61828d8d-6bd4-431f-9390-00b90a945dbe.png)

## Actual Behavior

![image](https://user-images.githubusercontent.com/63189531/141945221-d167953b-53aa-49b0-9d13-caac806b4f20.png)

## Proposed Fix

Basically the implementation of @amitkhare's [comment from StackOverflow on a question about the same subject](https://stackoverflow.com/a/7372377)